### PR TITLE
v3: split download & import, don't re-import if GTFS digest hasn't changed, add JS API

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,23 @@
+{
+	"extends": "eslint:recommended",
+	"env": {
+		"es2022": true,
+		"node": true
+	},
+	"parserOptions": {
+		"sourceType": "module"
+	},
+	"ignorePatterns": [
+		"node_modules"
+	],
+	"rules": {
+		"no-unused-vars": [
+			"error",
+			{
+				"vars": "all",
+				"args": "none",
+				"ignoreRestSiblings": false
+			}
+		]
+	}
+}

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -25,14 +25,14 @@ jobs:
     - name: compute Docker image tag
       id: docker-tags
       run: |
-        echo "permanent-tag=$(date +"%Y-%m-%dT%H.%M.%S")-${GITHUB_SHA:0:7}" >>$GITHUB_OUTPUT
+        echo "permanent-tag=v3-$(date +"%Y-%m-%dT%H.%M.%S")-${GITHUB_SHA:0:7}" >>$GITHUB_OUTPUT
 
     - name: build and push Docker image
       uses: docker/build-push-action@v5
       with:
         push: true
         tags: |
-          ghcr.io/${{ github.repository }}:2
+          ghcr.io/${{ github.repository }}:v3
           ghcr.io/${{ github.repository }}:${{ steps.docker-tags.outputs.permanent-tag }}
         platforms: linux/amd64
         # https://docs.docker.com/build/ci/github-actions/cache/#cache-backend-api

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -12,6 +12,14 @@ jobs:
     - name: checkout
       uses: actions/checkout@v4
 
+    - name: setup Node v${{ matrix.node-version }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+    - run: npm install
+
+    - run: npm run lint
+
     - name: set up Docker buildx
       uses: docker/setup-buildx-action@v3
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,11 +52,6 @@ RUN \
 	&& chmod +x /usr/local/bin/gtfstidy
 
 # todo: gtfs-via-postgres is Prosperity-dual-licensed, obtain a purely Apache-licensed version
-# todo: Docker layer caching won't pull the latest 4.x release
-RUN \
-	npm install -g gtfs-via-postgres@'^4.9.0' \
-	&& npm cache clean --force
-
 ADD package.json ./
 RUN npm install --omit dev && npm cache clean --force
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,8 @@ RUN apt update && apt install -y \
 # > A script such as homedir.mjs does not need to be executable on Unix because npm installs it via an executable symbolic link […].
 # https://exploringjs.com/nodejs-shell-scripting/ch_creating-shell-scripts.html#how-npm-installs-shell-scripts
 ADD \
-	--checksum=sha256:95b995d6e30cb765a02c14f265526801664ea9e03a090951cab0aee7fed103ee \
-	https://gist.github.com/derhuerst/745cf09fe5f3ea2569948dd215bbfe1a/raw/6df4a02302d77edac674fec52ed1c0b32a795a37/mirror.mjs \
+	--checksum=sha256:59bb1efdeef33ea380f1035fae0c3810a3063de2f400d0542695ab1bc8b9f95d \
+	https://gist.github.com/derhuerst/745cf09fe5f3ea2569948dd215bbfe1a/raw/cefaf64e2dd5bfde30de12017c4823cdc89ac64c/mirror.mjs \
 	/opt/curl-mirror.mjs
 RUN \
 	ln -s /opt/curl-mirror.mjs /usr/local/bin/curl-mirror && \

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The [`ghcr.io/mobidata-bw/postgis-gtfs-importer` Docker image](https://github.co
 
 First, the GTFS data is downloaded to, unzipped into and [tidied](https://github.com/patrickbr/gtfstidy) within `/tmp/gtfs`; You can specify a custom path using `$GTFS_TMP_DIR`.
 
-**Each GTFS import gets its own PostgreSQL database** called `$GTFS_IMPORTER_DB_PREFIX_$unix_timestamp`. The importer keeps track of the latest import by – once an import has succeeded – writing its DB name into a table `latest_import` within a "meta bookkeeping database".
+**Each GTFS import gets its own PostgreSQL database** called `$GTFS_IMPORTER_DB_PREFIX_$unix_timestamp_$sha256_digest`. The importer keeps track of the latest import by – once an import has succeeded – writing the import's DB name into a table `latest_import` within a "meta bookkeeping database".
 
 Before each import, it also **deletes all imports but the most recent two**; This ensures that your disk won't overflow but that a rollback to the previous import is always possible.
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ docker run --rm -it \
 	-v $PWD/gtfs-tmp:/tmp/gtfs \
 	-e 'GTFS_DOWNLOAD_USER_AGENT=…' \
 	-e 'GTFS_DOWNLOAD_URL=…' \
-	ghcr.io/mobidata-bw/postgis-gtfs-importer
+	ghcr.io/mobidata-bw/postgis-gtfs-importer:v3
 ```
 
 *Note:* We mount a `gtfs-tmp` directory to prevent it from re-downloading the GTFS dataset every time, even when it hasn't changed.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ First, the GTFS data is downloaded to, unzipped into and [tidied](https://github
 
 **Each GTFS import gets its own PostgreSQL database** called `$GTFS_IMPORTER_DB_PREFIX_$unix_timestamp_$sha256_digest`. The importer keeps track of the latest import by – once an import has succeeded – writing the import's DB name into a table `latest_import` within a "meta bookkeeping database".
 
+The newly downloaded GTFS data will only get imported if it has changed since the last import. This is determined using the [SHA-256 digest](https://en.wikipedia.org/wiki/SHA-2).
+
 Before each import, it also **deletes all imports but the most recent two**; This ensures that your disk won't overflow but that a rollback to the previous import is always possible.
 
 Because the entire import script runs in a [transaction](https://www.postgresql.org/docs/14/tutorial-transactions.html), and because it acquires an exclusive [lock](https://www.postgresql.org/docs/14/explicit-locking.html) on on `latest_import` in the beginning, it **should be safe to abort an import at any time**, or to (accidentally) run more than one process in parallel. Because creating and deleting DBs is *not* possible within a transaction, the importer opens a separate DB connection to do that; Therefore, aborting an import might leave an empty DB (not marked as the latest yet), which will be cleaned up as part of the next import (see above).

--- a/download.sh
+++ b/download.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -e
+set -u
+set -E # abort if subshells fail
+set -o pipefail
+
+source "$(dirname "$(realpath "$0")")/lib.sh"
+
+ua="${GTFS_DOWNLOAD_USER_AGENT:?'missing/empty $GTFS_DOWNLOAD_USER_AGENT'}"
+gtfs_url="${GTFS_DOWNLOAD_URL:?'missing/empty $GTFS_DOWNLOAD_URL'}"
+
+print_bold "Downloading the GTFS feed from $GTFS_DOWNLOAD_URL."
+set -x
+
+mkdir -p "$gtfs_tmp_dir"
+
+# custom curl-based HTTP mirroring/download script
+# > curl-mirror [--tmp-prefix …] [--log-level …] [--debug-curl] <url> <dest-path> [-- curl-opts...]
+# see https://gist.github.com/derhuerst/745cf09fe5f3ea2569948dd215bbfe1a
+	# --times \
+curl-mirror \
+	--tmp-prefix "$zip_path.mirror-" \
+	"$gtfs_url" "$zip_path" \
+	-- \
+	-H "User-Agent: $ua"

--- a/import.js
+++ b/import.js
@@ -126,7 +126,7 @@ const importGtfsAtomically = async (cfg) => {
 
 	// todo: DRY with lib.sh
 	const zipPath = `${tmpDir}/gtfs.zip`
-	logger.info(`downloading data to "${zipPath}"\n`)
+	logger.info(`downloading data to "${zipPath}"`)
 	const _t0Download = performance.now()
 	await pSpawn(pathToDownloadScript, [], {
 		stdio: 'inherit',
@@ -236,7 +236,7 @@ const importGtfsAtomically = async (cfg) => {
 		logger.debug(`creating database "${dbName}"`)
 		await dbMngmtClient.query(pgFormat('CREATE DATABASE %I', dbName))
 
-		logger.info(`importing data into "${dbName}"\n`)
+		logger.info(`importing data into "${dbName}"`)
 		const _importEnv = {
 			...process.env,
 			PGDATABASE: dbName,
@@ -267,7 +267,7 @@ const importGtfsAtomically = async (cfg) => {
 		})
 		result.importDurationMs = performance.now() - _t0Import
 
-		logger.info(`\nmarking the import into "${dbName}" as the latest`)
+		logger.info(`marking the import into "${dbName}" as the latest`)
 		await client.query(`\
 			INSERT INTO latest_import (db_name, always_true)
 			VALUES ($1, True)
@@ -304,6 +304,7 @@ const importGtfsAtomically = async (cfg) => {
 		client.end()
 	}
 
+	logger.debug('done!')
 	return result
 }
 

--- a/import.js
+++ b/import.js
@@ -1,0 +1,164 @@
+import {spawn} from 'node:child_process'
+import {onExit} from 'signal-exit'
+import {fileURLToPath} from 'node:url'
+import _pg from 'pg'
+const {Client} = _pg
+import pgFormat from 'pg-format'
+import {ok} from 'node:assert'
+import {writeFile} from 'node:fs/promises'
+
+const PATH_TO_IMPORT_SCRIPT = fileURLToPath(new URL('import.sh', import.meta.url).href)
+
+const pSpawn = (path, args = [], opts = {}) => {
+	return new Promise((resolve, reject) => {
+		const proc = spawn(PATH_TO_IMPORT_SCRIPT, args, opts)
+		// https://github.com/sindresorhus/execa/blob/f4b8b3ab601c94d1503f1010822952758dcc6350/lib/kill.js#L95-L101
+		const stopListening = onExit(() => {
+			proc.kill()
+		})
+		proc.once('error', (err) => {
+			reject(err)
+			stopListening()
+			proc.kill()
+		})
+		proc.once('exit', (code, signal) => {
+			if (code === 0) {
+				resolve()
+			} else {
+				const err = new Error(`${PATH_TO_IMPORT_SCRIPT} exited with ${code} (${signal})`)
+				err.code = code
+				err.signal = signal
+				err.proc = proc
+				reject(err)
+			}
+			stopListening()
+		})
+	})
+}
+
+const importGtfsAtomically = async (cfg) => {
+	const {
+		logger,
+		databaseNamePrefix,
+		pathToImportScript,
+		pathToDsnFile,
+	} = {
+		logger: console,
+		pathToImportScript: PATH_TO_IMPORT_SCRIPT,
+		pathToDsnFile: process.env.GTFS_IMPORTER_DSN_FILE || null,
+		...cfg,
+	}
+	ok(databaseNamePrefix, 'missing/empty cfg.databaseNamePrefix')
+	ok(pathToImportScript, 'missing/empty cfg.pathToImportScript')
+
+	// `CREATE/DROP DATABASE` can't be run within the transation, so we need need a separate client for it.
+	// Thus, a newly created database also won't be removed if the transaction fails or is aborted, so we
+	// have to drop it manually when cleaning up failed/aborted imports.
+	const dbMngmtClient = new Client()
+	await dbMngmtClient.connect()
+
+	const client = new Client()
+	await client.connect()
+
+	// We only ever keep one row in `latest_import`, which contains NULL in the beginning.
+	await client.query(`\
+		CREATE TABLE IF NOT EXISTS latest_import (
+			db_name TEXT,
+			always_true BOOLEAN DEFAULT True UNIQUE
+		);
+		INSERT INTO latest_import (db_name, always_true)
+		VALUES (NULL, True)
+		ON CONFLICT (always_true) DO NOTHING;
+	`)
+
+	await client.query('BEGIN')
+	try {
+		logger.info('obtaining exclusive lock on "latest_import", so that only one import can be running')
+		// https://www.postgresql.org/docs/14/explicit-locking.html#LOCKING-TABLES
+		// > Conflicts with the ROW SHARE, ROW EXCLUSIVE, SHARE UPDATE EXCLUSIVE, SHARE, SHARE ROW EXCLUSIVE, EXCLUSIVE, and ACCESS EXCLUSIVE lock modes. This mode allows only concurrent ACCESS SHARE locks, i.e., only reads from the table can proceed in parallel with a transaction holding this lock mode.
+		//> Only an ACCESS EXCLUSIVE lock blocks a SELECT (without FOR UPDATE/SHARE) statement.
+		await client.query('LOCK TABLE latest_import IN EXCLUSIVE MODE NOWAIT')
+
+		logger.debug('checking previous imports')
+
+		const {
+			rows: [{
+				db_name: prevImport,
+			}],
+		} = await client.query('SELECT db_name FROM latest_import')
+		if (prevImport !== null) {
+			logger.info(`latest import is in database "${prevImport}", keeping it until the new import has succeeded`)
+		}
+
+		{
+			const res = await client.query(`\
+				SELECT datname AS db_name
+				FROM pg_catalog.pg_database
+				WHERE datname != $1
+			`, [prevImport])
+			const dbsToCleanUp = res.rows
+			.map(r => r.db_name)
+			.filter(dbName => dbName.slice(0, databaseNamePrefix.length) === databaseNamePrefix)
+			.filter(dbName => /^\d+$/.test(dbName.slice(databaseNamePrefix.length)))
+
+			for (const dbName of dbsToCleanUp) {
+				logger.info(`dropping database "${dbName}" containing an older or unfinished import`)
+				await dbMngmtClient.query(pgFormat('DROP DATABASE %I', dbName))
+			}
+		}
+
+		const dbName = databaseNamePrefix + (Date.now() / 1000 | 0)
+
+		logger.debug(`creating database "${dbName}"`)
+		await dbMngmtClient.query(pgFormat('CREATE DATABASE %I', dbName))
+
+		logger.info(`importing data into "${dbName}"\n`)
+		await pSpawn(pathToImportScript, [], {
+			stdio: 'inherit',
+			env: {
+				...process.env,
+				PGDATABASE: dbName,
+			},
+		})
+
+		logger.info(`\nmarking the import into "${dbName}" as the latest`)
+		await client.query(`\
+			INSERT INTO latest_import (db_name, always_true)
+			VALUES ($1, True)
+			ON CONFLICT (always_true) DO UPDATE SET db_name = $1;
+		`, [dbName])
+
+		if (pathToDsnFile !== null) {
+			// https://www.pgbouncer.org/config.html#section-databases
+			// https://www.postgresql.org/docs/15/libpq-connect.html#id-1.7.3.8.3.5
+			const {
+				PGHOST,
+				POSTGREST_USER,
+				POSTGREST_PASSWORD,
+			} = process.env
+			ok(PGHOST, 'missing/empty $PGHOST')
+			ok(POSTGREST_USER, 'missing/empty $POSTGREST_USER')
+			ok(POSTGREST_PASSWORD, 'missing/empty $POSTGREST_PASSWORD')
+
+			const dsn = `gtfs=host=${PGHOST} dbname=${dbName} user=${POSTGREST_USER} password=${POSTGREST_PASSWORD}`
+			const logDsn = `gtfs=host=${PGHOST} dbname=${dbName} user=${POSTGREST_USER} password=${POSTGREST_PASSWORD.slice(0, 2)}…${POSTGREST_PASSWORD.slice(-2)}`
+			logger.debug(`writing "${logDsn}" into env file ${pathToDsnFile}`)
+			await writeFile(pathToDsnFile, dsn)
+		}
+
+		logger.info('import succeeded, committing all changes to "latest_import"!')
+		await client.query('COMMIT')
+	} catch (err) {
+		logger.warn('an error occured, rolling back')
+		// The newly created DB will remain, potentially with data inside. But it will be cleaned up during the next run.
+		await client.query('ROLLBACK')
+		throw err
+	}
+
+	dbMngmtClient.end()
+	client.end()
+}
+
+export {
+	importGtfsAtomically,
+}

--- a/import.js
+++ b/import.js
@@ -9,6 +9,15 @@ import pgFormat from 'pg-format'
 import {deepStrictEqual, fail, ok} from 'node:assert'
 import {writeFile} from 'node:fs/promises'
 
+// expose npm-installed local CLI tools to child processes
+import {createRequire} from 'node:module'
+import {dirname} from 'node:path'
+// todo: use import.meta.resolve once it is stable?
+// see https://nodejs.org/docs/latest-v20.x/api/esm.html#importmetaresolvespecifier
+const require = createRequire(import.meta.url)
+const GTFS_VIA_POSTGRES_PKG = require.resolve('gtfs-via-postgres/package.json')
+const NPM_BIN_DIR = dirname(dirname(GTFS_VIA_POSTGRES_PKG)) + '/.bin'
+
 const PATH_TO_IMPORT_SCRIPT = fileURLToPath(new URL('import.sh', import.meta.url).href)
 const PATH_TO_DOWNLOAD_SCRIPT = fileURLToPath(new URL('download.sh', import.meta.url).href)
 
@@ -239,6 +248,7 @@ const importGtfsAtomically = async (cfg) => {
 		logger.info(`importing data into "${dbName}"`)
 		const _importEnv = {
 			...process.env,
+			PATH: NPM_BIN_DIR + ':' + process.env.PATH,
 			PGDATABASE: dbName,
 			GTFS_TMP_DIR: tmpDir,
 		}

--- a/import.js
+++ b/import.js
@@ -53,6 +53,7 @@ const importGtfsAtomically = async (cfg) => {
 		logger,
 		pgHost, pgUser, pgPassword, pgMetaDatabase,
 		databaseNamePrefix,
+		schemaName,
 		pathToImportScript,
 		pathToDownloadScript,
 		pathToDsnFile,
@@ -68,6 +69,7 @@ const importGtfsAtomically = async (cfg) => {
 		pgUser: null,
 		pgPassword: null,
 		pgMetaDatabase: process.env.PGDATABASE || null,
+		schemaName: process.env.GTFS_IMPORTER_SCHEMA || null,
 		pathToImportScript: PATH_TO_IMPORT_SCRIPT,
 		pathToDownloadScript: PATH_TO_DOWNLOAD_SCRIPT,
 		pathToDsnFile: process.env.GTFS_IMPORTER_DSN_FILE || null,
@@ -225,6 +227,9 @@ const importGtfsAtomically = async (cfg) => {
 		}
 		if (pgPassword !== null) {
 			_importEnv.PGPASSWORD = pgPassword
+		}
+		if (schemaName !== null) {
+			_importEnv.GTFS_IMPORTER_SCHEMA = schemaName
 		}
 		if (gtfstidyBeforeImport !== null) {
 			_importEnv.GTFSTIDY_BEFORE_IMPORT = String(gtfstidyBeforeImport)

--- a/import.sh
+++ b/import.sh
@@ -4,38 +4,14 @@ set -u
 set -E # abort if subshells fail
 set -o pipefail
 
-print_bold () {
-	if [ -t 0 ]; then
-		echo "$(tput bold)$1$(tput sgr0)"
-	else
-		echo "$1"
-	fi
-}
+source "$(dirname "$(realpath "$0")")/lib.sh"
 
-ua="${GTFS_DOWNLOAD_USER_AGENT:?'missing/empty $GTFS_DOWNLOAD_USER_AGENT'}"
-gtfs_url="${GTFS_DOWNLOAD_URL:?'missing/empty $GTFS_DOWNLOAD_URL'}"
-gtfs_tmp_dir="${GTFS_TMP_DIR:-/tmp/gtfs}"
-mkdir -p "$gtfs_tmp_dir"
-
-zip_path="$gtfs_tmp_dir/gtfs.zip"
-extracted_path="$gtfs_tmp_dir/gtfs"
-tidied_path="$gtfs_tmp_dir/tidied.gtfs"
 gtfs_path=''
 
 sql_d_path="${GTFS_SQL_D_PATH:-/etc/gtfs/sql.d}"
 
-print_bold "Downloading & extracting the GTFS feed from $GTFS_DOWNLOAD_URL."
+print_bold "Extracting the GTFS feed."
 set -x
-
-# custom curl-based HTTP mirroring/download script
-# > curl-mirror [--tmp-prefix …] [--log-level …] [--debug-curl] <url> <dest-path> [-- curl-opts...]
-# see https://gist.github.com/derhuerst/745cf09fe5f3ea2569948dd215bbfe1a
-curl-mirror \
-	--tmp-prefix "$zip_path.mirror-" \
-	--times \
-	"$gtfs_url" "$zip_path" \
-	-- \
-	-H "User-Agent: $ua"
 
 rm -rf "$extracted_path"
 unzip -d "$extracted_path" "$zip_path"

--- a/import.sh
+++ b/import.sh
@@ -32,6 +32,7 @@ set -x
 # see https://gist.github.com/derhuerst/745cf09fe5f3ea2569948dd215bbfe1a
 curl-mirror \
 	--tmp-prefix "$zip_path.mirror-" \
+	--times \
 	"$gtfs_url" "$zip_path" \
 	-- \
 	-H "User-Agent: $ua"

--- a/import.sh
+++ b/import.sh
@@ -54,7 +54,8 @@ gtfs-to-sql -d \
 	--trips-without-shape-id --lower-case-lang-codes \
 	--stops-location-index \
 	--import-metadata \
-	--schema api --postgrest \
+	--schema "${GTFS_IMPORTER_SCHEMA:-api}" \
+	--postgrest \
 	"$gtfs_path/"*.txt \
 	| zstd | sponge | zstd -d \
 	| psql -b -v 'ON_ERROR_STOP=1'

--- a/importer.js
+++ b/importer.js
@@ -1,155 +1,26 @@
 #!/usr/bin/env node
 
-import {spawn} from 'node:child_process'
-import {onExit} from 'signal-exit'
-import {fileURLToPath} from 'node:url'
-import _pg from 'pg'
-const {Client} = _pg
-import pgFormat from 'pg-format'
-import {ok} from 'node:assert'
-import {writeFile} from 'node:fs/promises'
+import {importGtfsAtomically} from './import.js'
 
-const PATH_TO_IMPORT_SCRIPT = fileURLToPath(new URL('import.sh', import.meta.url).href)
+const GTFS_DOWNLOAD_USER_AGENT = process.env.GTFS_DOWNLOAD_USER_AGENT
+if (!GTFS_DOWNLOAD_USER_AGENT) {
+	console.error('Missing/empty $GTFS_DOWNLOAD_USER_AGENT.')
+	process.exit(1)
+}
+const GTFS_DOWNLOAD_URL = process.env.GTFS_DOWNLOAD_URL
+if (!GTFS_DOWNLOAD_URL) {
+	console.error('Missing/empty $GTFS_DOWNLOAD_URL.')
+	process.exit(1)
+}
 
 const GTFS_IMPORTER_DB_PREFIX = process.env.GTFS_IMPORTER_DB_PREFIX
 if (!GTFS_IMPORTER_DB_PREFIX) {
 	console.error('Missing/empty $GTFS_IMPORTER_DB_PREFIX.')
 	process.exit(1)
 }
-const DB_PREFIX = GTFS_IMPORTER_DB_PREFIX + '_'
 
-const PATH_TO_DSN_FILE = process.env.GTFS_IMPORTER_DSN_FILE || null
-
-const pSpawn = (path, args = [], opts = {}) => {
-	return new Promise((resolve, reject) => {
-		const proc = spawn(PATH_TO_IMPORT_SCRIPT, args, opts)
-		// https://github.com/sindresorhus/execa/blob/f4b8b3ab601c94d1503f1010822952758dcc6350/lib/kill.js#L95-L101
-		const stopListening = onExit(() => {
-			proc.kill()
-		})
-		proc.once('error', (err) => {
-			reject(err)
-			stopListening()
-			proc.kill()
-		})
-		proc.once('exit', (code, signal) => {
-			if (code === 0) {
-				resolve()
-			} else {
-				const err = new Error(`${PATH_TO_IMPORT_SCRIPT} exited with ${code} (${signal})`)
-				err.code = code
-				err.signal = signal
-				err.proc = proc
-				reject(err)
-			}
-			stopListening()
-		})
-	})
-}
-
-// `CREATE/DROP DATABASE` can't be run within the transation, so we need need a separate client for it.
-// Thus, a newly created database also won't be removed if the transaction fails or is aborted, so we
-// have to drop it manually when cleaning up failed/aborted imports.
-const dbMngmtClient = new Client()
-await dbMngmtClient.connect()
-
-const client = new Client()
-await client.connect()
-
-// We only ever keep one row in `latest_import`, which contains NULL in the beginning.
-await client.query(`\
-	CREATE TABLE IF NOT EXISTS latest_import (
-		db_name TEXT,
-		always_true BOOLEAN DEFAULT True UNIQUE
-	);
-	INSERT INTO latest_import (db_name, always_true)
-	VALUES (NULL, True)
-	ON CONFLICT (always_true) DO NOTHING;
-`)
-
-await client.query('BEGIN')
-try {
-	console.info('obtaining exclusive lock on "latest_import", so that only one import can be running')
-	// https://www.postgresql.org/docs/14/explicit-locking.html#LOCKING-TABLES
-	// > Conflicts with the ROW SHARE, ROW EXCLUSIVE, SHARE UPDATE EXCLUSIVE, SHARE, SHARE ROW EXCLUSIVE, EXCLUSIVE, and ACCESS EXCLUSIVE lock modes. This mode allows only concurrent ACCESS SHARE locks, i.e., only reads from the table can proceed in parallel with a transaction holding this lock mode.
-	//> Only an ACCESS EXCLUSIVE lock blocks a SELECT (without FOR UPDATE/SHARE) statement.
-	await client.query('LOCK TABLE latest_import IN EXCLUSIVE MODE NOWAIT')
-	
-	console.info('')
-
-	const {
-		rows: [{
-			db_name: prevImport,
-		}],
-	} = await client.query('SELECT db_name FROM latest_import')
-	if (prevImport !== null) {
-		console.info(`latest import is in database "${prevImport}", keeping it until the new import has succeeded`)
-	}
-
-	{
-		const res = await client.query(`\
-			SELECT datname AS db_name
-			FROM pg_catalog.pg_database
-			WHERE datname != $1
-		`, [prevImport])
-		const dbsToCleanUp = res.rows
-		.map(r => r.db_name)
-		.filter(dbName => dbName.slice(0, DB_PREFIX.length) === DB_PREFIX)
-		.filter(dbName => /^\d+$/.test(dbName.slice(DB_PREFIX.length)))
-
-		for (const dbName of dbsToCleanUp) {
-			console.info(`dropping database "${dbName}" containing an older or unfinished import`)
-			await dbMngmtClient.query(pgFormat('DROP DATABASE %I', dbName))
-		}
-	}
-
-	console.info('')
-	const dbName = DB_PREFIX + (Date.now() / 1000 | 0)
-
-	console.info(`creating database "${dbName}"`)
-	await dbMngmtClient.query(pgFormat('CREATE DATABASE %I', dbName))
-
-	console.info(`importing data into "${dbName}"\n`)
-	await pSpawn(PATH_TO_IMPORT_SCRIPT, [], {
-		stdio: 'inherit',
-		env: {
-			...process.env,
-			PGDATABASE: dbName,
-		},
-	})
-
-	console.info(`\nmarking the import into "${dbName}" as the latest`)
-	await client.query(`\
-		INSERT INTO latest_import (db_name, always_true)
-		VALUES ($1, True)
-		ON CONFLICT (always_true) DO UPDATE SET db_name = $1;
-	`, [dbName])
-
-	if (PATH_TO_DSN_FILE !== null) {
-		// https://www.pgbouncer.org/config.html#section-databases
-		// https://www.postgresql.org/docs/15/libpq-connect.html#id-1.7.3.8.3.5
-		const {
-			PGHOST,
-			POSTGREST_USER,
-			POSTGREST_PASSWORD,
-		} = process.env
-		ok(PGHOST, 'missing/empty $PGHOST')
-		ok(POSTGREST_USER, 'missing/empty $POSTGREST_USER')
-		ok(POSTGREST_PASSWORD, 'missing/empty $POSTGREST_PASSWORD')
-
-		const dsn = `gtfs=host=${PGHOST} dbname=${dbName} user=${POSTGREST_USER} password=${POSTGREST_PASSWORD}`
-		const logDsn = `gtfs=host=${PGHOST} dbname=${dbName} user=${POSTGREST_USER} password=${POSTGREST_PASSWORD.slice(0, 2)}…${POSTGREST_PASSWORD.slice(-2)}`
-		console.info(`writing "${logDsn}" into env file ${PATH_TO_DSN_FILE}`)
-		await writeFile(PATH_TO_DSN_FILE, dsn)
-	}
-
-	console.info('import succeeded, committing all changes to "latest_import"!')
-	await client.query('COMMIT')
-} catch (err) {
-	console.info('rolling back')
-	await client.query('ROLLBACK')
-	throw err
-}
-
-dbMngmtClient.end()
-client.end()
+await importGtfsAtomically({
+	gtfsDownloadUserAgent: GTFS_DOWNLOAD_USER_AGENT,
+	gtfsDownloadUrl: GTFS_DOWNLOAD_URL,
+	databaseNamePrefix: GTFS_IMPORTER_DB_PREFIX + '_',
+})

--- a/lib.sh
+++ b/lib.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+print_bold () {
+	if [ -t 0 ]; then
+		echo "$(tput bold)$1$(tput sgr0)"
+	else
+		echo "$1"
+	fi
+}
+
+gtfs_tmp_dir="${GTFS_TMP_DIR:-/tmp/gtfs}"
+
+zip_path="$gtfs_tmp_dir/gtfs.zip"
+extracted_path="$gtfs_tmp_dir/gtfs"
+tidied_path="$gtfs_tmp_dir/tidied.gtfs"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
 		"node": ">=20"
 	},
 	"dependencies": {
+		"gtfs-via-postgres": "^4.10.0",
 		"pg": "^8.11.3",
 		"pg-format": "^1.0.4",
 		"signal-exit": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -11,5 +11,11 @@
 		"pg": "^8.11.3",
 		"pg-format": "^1.0.4",
 		"signal-exit": "^4.1.0"
+	},
+	"devDependencies": {
+		"eslint": "^8.57.0"
+	},
+	"scripts": {
+		"lint": "eslint ."
 	}
 }


### PR DESCRIPTION
From a user's perspective, this PR mainly changes `postgis-gtfs-importer` in the following ways:

- **Data is only imported when it has changed.** When the GTFS archive's digest hasn't changed, data is not re-imported. For this two work, I had to change the database naming scheme to `$GTFS_IMPORTER_DB_PREFIX_$sha256_digest_$unix_timestamp`. Databases with the old naming scheme will have to be removed manually.
- There is a new JS API, used by another project of mine. The existing shell API just wraps the JS API in a backwards-compatible way, with the breaking change mentioned above (and those minor ones in the commit messages).
