### PR TITLE
Allow custom gtfs-to-sql arguments via ENV variable during GTFS import

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ You can configure access to the PostgreSQL by passing the [standard `PG*` enviro
 
 If you run with `GTFSTIDY_BEFORE_IMPORT=false`, [gtfsclean](https://github.com/public-transport/gtfsclean) (a fork of [gtfstidy](https://github.com/patrickbr/gtfstidy)) will not be used.
 
+You can pass additional options to the underlying [`gtfs-to-sql`](https://github.com/public-transport/gtfs-via-postgres) command using `$GTFS_TO_SQL_ADDITIONAL_ARGS`, e.g. to import a GTFS feed using [extended route types](https://developers.google.com/transit/gtfs/reference/extended-route-types) (as used e.g. by Swiss GTFS feeds):
+
+```shell
+-e 'GTFS_TO_SQL_ADDITIONAL_ARGS=--route-types-scheme google-extended'
+```
+
+Keep in mind that `\` characters in `$GTFS_TO_SQL_ADDITIONAL_ARGS` will be interpreted because the variable is processed using Bash's `read` *without* the `-r` flag. For example, setting `GTFS_TO_SQL_ADDITIONAL_ARGS='--foo bar\ baz'` will pass *two* arguments `--foo` & `bar baz` to `gtfs-to-sql`.
+
 ### writing a DSN file
 
 If you set `$PATH_TO_DSN_FILE` to a file path, the importer will also write a [PostgreSQL key/value connection string (DSN)](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING-KEYWORD-VALUE) to that path. Note that you must also provide `$POSTGREST_USER` & `$POSTGREST_PASSWORD` in this case.

--- a/import.sh
+++ b/import.sh
@@ -120,6 +120,8 @@ if [ "$verbose" = false ]; then
 	psql_args+=('--quiet')
 	gtfs_to_sql_args+=('--silent')
 fi
+# e.g. GTFS_TO_SQL_ADDITIONAL_ARGS='--route-types-scheme google-extended' for Swiss GTFS feeds
+read -a gtfs_to_sql_additional_args <<< "${GTFS_TO_SQL_ADDITIONAL_ARGS:-}"
 
 gtfs-to-sql -d "${gtfs_to_sql_args[@]}" \
 	--trips-without-shape-id --lower-case-lang-codes \
@@ -127,6 +129,7 @@ gtfs-to-sql -d "${gtfs_to_sql_args[@]}" \
 	--import-metadata \
 	--schema "${GTFS_IMPORTER_SCHEMA:-public}" \
 	--postgrest \
+	"${gtfs_to_sql_additional_args[@]}" \
 	"$gtfs_path/"*.txt \
 	| zstd | sponge | zstd -d \
 	| psql -b -v 'ON_ERROR_STOP=1' "${psql_args[@]}"


### PR DESCRIPTION
Not all GTFS feeds import successfully with `gtfs-to-sql`'s defaults. For example, feeds using [extended route type codes](https://developers.google.com/transit/gtfs/reference/extended-route-types), like the [Swiss GTFS](https://opentransportdata.swiss/de/cookbook/timetable-cookbook/gtfs/#routestxt) need special handling:

> Unser Datensatz benutzt Werte aus dieser [weit verbreiteten Liste](https://developers.google.com/transit/gtfs/reference/extended-route-types) von `route_type` in Abweichung von der [Liste gemäss Standard](https://gtfs.org/documentation/schedule/reference/#routestxt) (welcher nur zehn Werte für route_type kennt)

This change adds the possibility to specify custom `gtfs-to-sql` arguments via `$GTFS_TO_SQL_ADDITIONAL_ARGS` in `import.sh`. In the example above, using the argument `--route-types-scheme google-extended` is used to handle the extended route type codes.
